### PR TITLE
feat: Optimize image loading for multi-image articles

### DIFF
--- a/assets/tufted.css
+++ b/assets/tufted.css
@@ -45,6 +45,12 @@ svg {
 	width: auto;
 }
 
+/* Give lazy-loaded images a non-zero offscreen placeholder for layout. */
+img[loading="lazy"] {
+	content-visibility: auto;
+	contain-intrinsic-size: auto 400px;
+}
+
 /*
    CONTENT ALIGNMENT & CENTERING
    Shared logic for images, SVGs

--- a/tufted-lib/figures.typ
+++ b/tufted-lib/figures.typ
@@ -12,12 +12,30 @@
     if target() == "html" and type(it.source) == str {
       let alt = if it.alt == none { "" } else { it.alt }
 
-      html.img(
-        src: it.source,
-        alt: alt,
-        loading: "lazy",
-        decoding: "async",
-      )
+      let dims = measure(it)
+      let img-w = int(dims.width.pt())
+      let img-h = int(dims.height.pt())
+
+      // When use scale to resize an image (e.g., `width: 50%`),
+      // the measured dimensions are zero.
+      // `layout` is not available when exporting to HTML.
+      if img-w > 0 and img-h > 0 {
+        html.img(
+          src: it.source,
+          alt: alt,
+          loading: "lazy",
+          decoding: "async",
+          width: img-w,
+          height: img-h,
+        )
+      } else {
+        html.img(
+          src: it.source,
+          alt: alt,
+          loading: "lazy",
+          decoding: "async",
+        )
+      }
     } else {
       it
     }

--- a/tufted-lib/figures.typ
+++ b/tufted-lib/figures.typ
@@ -7,6 +7,22 @@
     it.supplement + sym.space.nobreak + it.counter.display() + it.separator + it.body,
   )
 
+  // Add lazy-loading related attributes to raster images in HTML output.
+  show image: it => context {
+    if target() == "html" and type(it.source) == str {
+      let alt = if it.alt == none { "" } else { it.alt }
+
+      html.img(
+        src: it.source,
+        alt: alt,
+        loading: "lazy",
+        decoding: "async",
+      )
+    } else {
+      it
+    }
+  }
+
   // Redefine figure itself
   show figure: it => if target() == "html" {
     html.figure({


### PR DESCRIPTION
This optimization was discussed in Discussion #29 

**Title**  
Optimize image post-processing for multi-image articles

**Description**  
This PR updates build.py only (`1 commit`, `1 file changed`, `+502/-0`).

### What changed
- Added `pillow>=10.0.0` script dependency.
- Improved `copy_assets()` to preserve generated inline-images during rebuild.
- Added `extract_inline_images()` to convert base64 inline images into static files.
- Added `optimize_inline_images()` to compress JPEGs with incremental manifest support.
- Added `generate_responsive_images()` to create responsive variants and inject `srcset/sizes/width/height`.
- Added `add_image_lazy_loading()` to inject lazy-loading related attributes.
- Wired the new post-processing steps into `build()`.

### Impact
- Mainly affects HTML output and image assets.
- Does not directly change the `build.py pdf` command path.