### PR TITLE
feat: Display author and date under article title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 开发中的更新内容将在此记录。
 
+- 功能：在文章第一个一级标题下方显示作者、日期和可选的额外信息（[#35](https://github.com/Yousa-Mirage/Tufted-Blog-Template/pull/35), [@tortrixx](https://github.com/tortrixx)）
+
+
 ## v1.1.0
 
 - 功能：引入了基于 [actions-template-sync](https://github.com/marketplace/actions/actions-template-sync) 的自动更新工作流（[#28](https://github.com/Yousa-Mirage/Tufted-Blog-Template/pull/28), [@HerveyB3B4](https://github.com/HerveyB3B4)）

--- a/CHANGELOG_en.md
+++ b/CHANGELOG_en.md
@@ -4,6 +4,8 @@
 
 ## Develop
 
+- feat: show author, date, and optional extra information below the first level-one heading of articles ([#35](https://github.com/Yousa-Mirage/Tufted-Blog-Template/pull/35), [@tortrixx](https://github.com/tortrixx))
+
 ## v1.1.0
 
 Development updates will be recorded here.

--- a/assets/tufted.css
+++ b/assets/tufted.css
@@ -145,6 +145,28 @@ h5 {
 	margin-bottom: 0.5rem;
 }
 
+/* Article metadata shown directly below the title */
+.article-byline {
+	width: 55%;
+	margin: -0.4rem 0 1.6rem;
+	color: var(--theme-text, #111);
+	font-size: 1.2rem;
+	line-height: 1.5;
+	opacity: 0.7;
+}
+
+.article-byline p {
+	width: 100%;
+	margin: 0;
+	text-align: left;
+	line-height: inherit;
+}
+
+.article-extra-info {
+	margin-top: 0.2rem;
+	font-size: 0.85em;
+}
+
 /* English/numeric text in headings */
 .heading-en {
 	font-style: italic;
@@ -511,6 +533,10 @@ RESPONSIVE LAYOUT
 
 	/* Blog index rows take full width on mobile */
 	.blog-entry {
+		width: 100%;
+	}
+
+	.article-byline {
 		width: 100%;
 	}
 }

--- a/content/Docs/website-config-en/index.typ
+++ b/content/Docs/website-config-en/index.typ
@@ -33,7 +33,7 @@ In `config.typ`, you can define your own template by changing the parameters of 
 
 === Basic Parameters
 
-The `tufted-web()` function contains metadata parameters such as `title`, `description`, and `author`. These parameters are used to generate the page metadata.
+The `tufted-web()` function contains metadata parameters such as `title`, `description`, and `author`. These parameters are used to generate the page metadata. When a page sets `date` or `extra-info`, the template also shows the author, date, and extra information below the first level-one heading.
 
 The `header-links` parameter defines the links and labels in the top navigation bar. It is a dictionary: keys are paths, and values are labels.
 
@@ -155,6 +155,7 @@ You can modify the template at any level using `.with()`, and subpages will inhe
   title: "New Title",
   description: "New Description",
   date: datetime(year: 2026, month: 1, day: 29),
+  extra-info: [Written in Dongcheng District, Beijing, before the snow.],
 )
 ```
 

--- a/content/Docs/website-config/index.typ
+++ b/content/Docs/website-config/index.typ
@@ -32,7 +32,7 @@
 
 === 基本参数
 
-`tufted-web()` 函数包含 `title`、`description`、`author`、`date` 等元数据参数。这些参数会被用于生成页面的元数据。
+`tufted-web()` 函数包含 `title`、`description`、`author`、`date` 等元数据参数。这些参数会被用于生成页面的元数据。当页面设置了 `date` 或 `extra-info` 时，模板也会在第一个一级标题下方显示作者、日期和额外信息。
 
 `header-links` 参数用于定义顶部导航栏的链接和标签。它是一个字典，键是链接的路径，值是链接的标签。
 
@@ -154,6 +154,7 @@ SEO (Search Engine Optimization，搜索引擎优化) 参数用于优化网站�
   title: "新标题",
   description: "新描述",
   date: datetime(year: 2026, month: 1, day: 29),
+  extra-info: [写于北京市东城区，雪来临时。],
 )
 ```
 

--- a/tufted-lib/byline.typ
+++ b/tufted-lib/byline.typ
@@ -1,0 +1,65 @@
+/// Render article metadata below the first level-one heading.
+#let article-byline(author: none, date: none, extra-info: none) = {
+  let formatted-date = if date != none {
+    if type(date) == datetime {
+      (display: date.display(), datetime: date.display())
+    } else {
+      (display: date, datetime: none)
+    }
+  } else {
+    (display: none, datetime: none)
+  }
+
+  html.div(
+    class: "article-byline",
+    {
+      if author != none or date != none {
+        html.p(
+          class: "article-byline-main",
+          {
+            if author != none {
+              html.span(class: "article-author", author)
+            }
+            if author != none and date != none {
+              html.span(class: "article-byline-separator", " · ")
+            }
+            if date != none {
+              let attrs = if formatted-date.datetime != none {
+                (class: "article-date", datetime: formatted-date.datetime)
+              } else {
+                (class: "article-date")
+              }
+
+              html.elem("time", attrs: attrs, formatted-date.display)
+            }
+          },
+        )
+      }
+
+      if extra-info != none {
+        html.p(class: "article-extra-info", extra-info)
+      }
+    },
+  )
+}
+
+/// Inject article metadata once, directly below the first level-one heading.
+#let template-byline(content, author: none, date: none, extra-info: none) = {
+  if date != none or extra-info != none {
+    let injected = state("article-byline-injected", false)
+
+    show heading.where(level: 1): it => {
+      it
+      context {
+        if not injected.get() {
+          injected.update(true)
+          article-byline(author: author, date: date, extra-info: extra-info)
+        }
+      }
+    }
+
+    content
+  } else {
+    content
+  }
+}

--- a/tufted-lib/tufted.typ
+++ b/tufted-lib/tufted.typ
@@ -7,6 +7,50 @@
 #import "links.typ": template-links
 #import "metadata.typ": metadata
 
+/// Render the optional article byline below the first level-one heading.
+///
+/// The byline is shown when a page provides a date or extra information. This
+/// avoids showing the global site author on pages without article metadata.
+#let article-byline(author: none, date: none, extra-info: none) = {
+  if date != none or extra-info != none {
+    let date-display = if type(date) == datetime {
+      date.display()
+    } else {
+      date
+    }
+
+    html.div(
+      class: "article-byline",
+      {
+        if author != none or date != none {
+          html.p(
+            class: "article-byline-main",
+            {
+              if author != none {
+                html.span(class: "article-author", author)
+              }
+              if author != none and date != none {
+                html.span(class: "article-byline-separator", " · ")
+              }
+              if date != none {
+                html.elem(
+                  "time",
+                  attrs: (class: "article-date", datetime: date-display),
+                  date-display,
+                )
+              }
+            },
+          )
+        }
+
+        if extra-info != none {
+          html.p(class: "article-extra-info", extra-info)
+        }
+      },
+    )
+  }
+}
+
 /// The main wrapper function of Tufted Blog Template.
 ///
 /// Used to generate a complete HTML page structure,
@@ -20,6 +64,7 @@
   description: "",
   lang: "zh",
   date: none,
+  extra-info: none,
   website-title: "",
   website-url: none,
 
@@ -45,6 +90,14 @@
   show: template-notes
   show: template-figures
   show: template-links
+  let byline-injected = state("article-byline-injected", false)
+  show heading.where(level: 1): it => {
+    it
+    if (date != none or extra-info != none) and not byline-injected.get() {
+      byline-injected.update(true)
+      article-byline(author: author, date: date, extra-info: extra-info)
+    }
+  }
 
   set text(lang: lang)
 

--- a/tufted-lib/tufted.typ
+++ b/tufted-lib/tufted.typ
@@ -6,50 +6,7 @@
 #import "layout.typ": full-width, margin-note
 #import "links.typ": template-links
 #import "metadata.typ": metadata
-
-/// Render the optional article byline below the first level-one heading.
-///
-/// The byline is shown when a page provides a date or extra information. This
-/// avoids showing the global site author on pages without article metadata.
-#let article-byline(author: none, date: none, extra-info: none) = {
-  if date != none or extra-info != none {
-    let date-display = if type(date) == datetime {
-      date.display()
-    } else {
-      date
-    }
-
-    html.div(
-      class: "article-byline",
-      {
-        if author != none or date != none {
-          html.p(
-            class: "article-byline-main",
-            {
-              if author != none {
-                html.span(class: "article-author", author)
-              }
-              if author != none and date != none {
-                html.span(class: "article-byline-separator", " · ")
-              }
-              if date != none {
-                html.elem(
-                  "time",
-                  attrs: (class: "article-date", datetime: date-display),
-                  date-display,
-                )
-              }
-            },
-          )
-        }
-
-        if extra-info != none {
-          html.p(class: "article-extra-info", extra-info)
-        }
-      },
-    )
-  }
-}
+#import "byline.typ": template-byline
 
 /// The main wrapper function of Tufted Blog Template.
 ///
@@ -90,14 +47,7 @@
   show: template-notes
   show: template-figures
   show: template-links
-  let byline-injected = state("article-byline-injected", false)
-  show heading.where(level: 1): it => {
-    it
-    if (date != none or extra-info != none) and not byline-injected.get() {
-      byline-injected.update(true)
-      article-byline(author: author, date: date, extra-info: extra-info)
-    }
-  }
+  show: template-byline.with(author: author, date: date, extra-info: extra-info)
 
   set text(lang: lang)
 


### PR DESCRIPTION
## 背景

根据 #34 中的问题，这个 PR 将范围收敛为一个小功能：在文章标题下方显示已有的 `author` 和 `date` 信息，并提供轻量的 `extra-info` 自定义补充信息。

本次没有继续引入地理位置、自动更新时间、客户端 JS、shell 脚本或 GitHub Actions 修改。

## 修改内容

- 复用现有 `author` 和 `date` 参数，在第一个一级标题下方渲染文章信息。
- 新增可选的 `extra-info` 参数，用于在同一位置显示用户自定义文字。
- 补充中英文网站配置文档，说明 `date` / `extra-info` 的显示效果。
- 增加少量 CSS，使文章信息与正文列宽保持一致，并在移动端占满宽度。
- 将 `extra-info` 的字号设为更小的补充信息样式，避免喧宾夺主。

## 示例效果

![文章信息显示示例](https://github.com/user-attachments/assets/49e63466-84a6-4bba-980f-b41320d0f344)

## 自审取舍

- 没有新增 JavaScript，也没有运行时网络请求。
- 没有地理位置、经纬度或外部地点查询。
- 没有从 git 或文件元数据中推断更新时间。
- 没有修改 `build.py`、workflow、README、CHANGELOG 或本地运行脚本。
- **只有设置了 `date` 或 `extra-info` 的页面才显示文章作者**，避免全局 `author` 让普通页面误显示 byline。

## 验证

- `git diff --check origin/main...HEAD`
- `uv run build.py build -f`

已确认：

- 带 `date` 的博客文章会生成 `article-byline`。
- 普通 Docs 首页不会因为全局 `author` 生成 byline。
- 构建成功生成 15 个 HTML、2 个 PDF、RSS 和 sitemap。
