### PR TITLE
Tune floating TOC width for better spacing across viewport layouts

### DIFF
--- a/assets/tufted.css
+++ b/assets/tufted.css
@@ -683,10 +683,10 @@ TABLE OF CONTENTS
 .toc-sidebar {
 	position: fixed;
 	top: 15rem;
-	left: 1rem;
+	left: 1%;
 	z-index: 10;
 	display: none;
-	width: 13%;
+	width: 10.5%;
 	max-height: calc(100vh - 11rem);
 	overflow-y: auto;
 	color: var(--theme-line-numbers-text, #aaa);


### PR DESCRIPTION
## 前言

在我尝试左侧浮动目录这个新特性的时候，我发现 width 默认值 13%，在部分窗口形态下表现不稳定，考虑到如今 16:10 比例的屏幕非常普及，且越来越多的用户习惯使用垂直标签页，重新定一个更好的默认值对博客主人、来访者来说都更友好，可以保持一致的阅读体验。

在我device 1 16:10 浏览器水平标签页的使用场景下，浮动目录会压到正文半个字

在我device 2 16:9 浏览器垂直标签页的使用场景下，浮动目录会紧贴正文

在我device 2 16:9 浏览器水平标签页的使用场景下，浮动目录显示正常

希望能找到一个折中的默认值能适配更多显示器方案、标签页方案的默认值。

## 测试截图

### 原版方案

left: 1rem; width:13%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/e6b9005b-bd9c-4fb9-a55a-13b4481f3a22" />

<img width="1470" height="956" alt="PixPin_2026-05-18_03-23-26" src="https://github.com/user-attachments/assets/53f4131c-50c0-4d42-bd52-401ddb534a3c" />

#### device 2

<img width="2560" height="1392" alt="1779043792552" src="https://github.com/user-attachments/assets/4d10dc4f-87cd-4c39-8552-9a25b4388295" />

<img width="2560" height="1392" alt="1779043811151" src="https://github.com/user-attachments/assets/248eb586-c802-4a43-b1a3-6f60e5e44e27" />



### 测试方案  1

left: 1%; width:12%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/e7fd0435-6f61-454a-92c0-2046ff2e9601" />

#### device 2

<img width="2560" height="1392" alt="1779044046467" src="https://github.com/user-attachments/assets/7897a6ab-2321-4e15-b673-1206953a0e92" />

<img width="2560" height="1392" alt="1779044023265" src="https://github.com/user-attachments/assets/3a57fb79-5602-44ba-afdf-8ea584d488ba" />

### 测试方案 2

left: 1%; width:11%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/570354c6-8762-471f-bda4-73f1c9f6e9ec" />

#### device 2

<img width="2560" height="1392" alt="1779044177371" src="https://github.com/user-attachments/assets/6171a699-1481-4960-9ab8-c2e29dc4a6cd" />

<img width="2560" height="1392" alt="1779044191256" src="https://github.com/user-attachments/assets/b6e2d6af-fc39-4321-91de-336d5f0d0d74" />

### 测试方案 3

left: 1%; width:10.5%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/9c5a9927-ef83-40df-b549-77c39775b3df" />

#### device 2

<img width="2560" height="1392" alt="1779044485524" src="https://github.com/user-attachments/assets/f0c3121b-ad80-4529-a296-e8f29945a864" />

<img width="2560" height="1392" alt="1779044502313" src="https://github.com/user-attachments/assets/6c98760b-be8e-43ed-8e91-bdeea3e57048" />


### 总结

从当前测试结果看，`left: 1%; width: 10.5%;` 在多个窗口形态下比原来的 `left: 1rem; width: 13%;` 更稳定，同时仍保留百分比布局，没有引入额外的 `calc()` / `clamp()` 复杂度。我目前没有覆盖 3:2 和超宽屏设备，因此具体比例仍欢迎进一步调整。

---

## Introduction

While testing the new "left-floating table of contents" feature, I noticed that the default width of 13% performed inconsistently across various window configurations. Given the widespread prevalence of 16:10 aspect ratio screens today—and the growing number of users who prefer using vertical tabs—establishing a more optimal default value would be more user-friendly for both blog owners and visitors, ensuring a consistent reading experience.

On my device 1 (16:10) with horizontal browser tabs, the floating TOC overlaps the main text by half a character.

On my device 2 (16:9) with vertical browser tabs, the floating TOC is pressed tightly against the main text.

On my device 2 (16:9) with horizontal browser tabs, the floating TOC displays normally.

I hope to find a balanced default value that can better accommodate various monitor setups and browser tab configurations.

## Test Screenshots

### Original Configuration

left: 1rem; width:13%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/e6b9005b-bd9c-4fb9-a55a-13b4481f3a22" />


#### device 2

<img width="2560" height="1392" alt="1779043792552" src="https://github.com/user-attachments/assets/4d10dc4f-87cd-4c39-8552-9a25b4388295" />

<img width="2560" height="1392" alt="1779043811151" src="https://github.com/user-attachments/assets/248eb586-c802-4a43-b1a3-6f60e5e44e27" />



### Test Configuration 1

left: 1%; width:12%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/e7fd0435-6f61-454a-92c0-2046ff2e9601" />

#### device 2

<img width="2560" height="1392" alt="1779044046467" src="https://github.com/user-attachments/assets/7897a6ab-2321-4e15-b673-1206953a0e92" />

<img width="2560" height="1392" alt="1779044023265" src="https://github.com/user-attachments/assets/3a57fb79-5602-44ba-afdf-8ea584d488ba" />

### Test Configuration 2

left: 1%; width:11%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/570354c6-8762-471f-bda4-73f1c9f6e9ec" />

#### device 2

<img width="2560" height="1392" alt="1779044177371" src="https://github.com/user-attachments/assets/6171a699-1481-4960-9ab8-c2e29dc4a6cd" />

<img width="2560" height="1392" alt="1779044191256" src="https://github.com/user-attachments/assets/b6e2d6af-fc39-4321-91de-336d5f0d0d74" />

### Test Configuration 3

left: 1%; width:10.5%;

#### device 1

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/9c5a9927-ef83-40df-b549-77c39775b3df" />

#### device 2

<img width="2560" height="1392" alt="1779044485524" src="https://github.com/user-attachments/assets/f0c3121b-ad80-4529-a296-e8f29945a864" />

<img width="2560" height="1392" alt="1779044502313" src="https://github.com/user-attachments/assets/6c98760b-be8e-43ed-8e91-bdeea3e57048" />


### Summary

Based on the current test results, `left: 1%; width: 10.5%;` is more stable across multiple window configurations than the original `left: 1rem; width: 13%;`. At the same time, it retains the percentage-based layout without introducing the extra complexity of `calc()` / `clamp()`. I currently haven't covered 3:2 and ultrawide screen devices, so further adjustments to the specific proportions are still welcome.
